### PR TITLE
Make chart data generation reproducible

### DIFF
--- a/.github/workflows/trunk.yml
+++ b/.github/workflows/trunk.yml
@@ -22,5 +22,3 @@ jobs:
 
       - name: Trunk Check
         uses: trunk-io/trunk-action@75699af9e26881e564e9d832ef7dc3af25ec031b # v1.2.4
-        with:
-          post-annotations: true

--- a/README.md
+++ b/README.md
@@ -6,6 +6,9 @@ different voting systems, electorate models, and strategic behaviors.
 See the [VSE FAQ](https://electionscience.github.io/vse-sim/) for an explanation
 of the methods and published results.
 
+See the [chart reproduction guide](docs/chart-reproduction.md) to generate the
+full simulation CSV used by the chart analysis.
+
 ## Setup
 
 The project supports Python 3.10 through 3.12 and uses

--- a/docs/chart-reproduction.md
+++ b/docs/chart-reproduction.md
@@ -1,0 +1,24 @@
+---
+title: Chart data reproduction
+layout: default
+permalink: /chart-reproduction
+---
+
+The published charts are derived from a full simulation CSV. Generate that CSV
+with the same settings used by the charts:
+
+```bash
+uv run python scripts/generate_published_results.py --elections 15000 \
+  --output artifacts/published-results
+```
+
+The command prints the generated filename. To explore that data with the
+historical R analysis, install `data.table` and `scatterD3`, then pass the CSV
+path explicitly:
+
+```bash
+Rscript vseCheck.R artifacts/published-results1.csv
+```
+
+The generated CSV is intentionally not committed. It records the model,
+methods, seed, and iteration count in its first line.

--- a/scripts/generate_published_results.py
+++ b/scripts/generate_published_results.py
@@ -1,0 +1,49 @@
+"""Generate the complete simulation CSV consumed by the chart analysis.
+
+Example:
+
+    uv run python scripts/generate_published_results.py --elections 15000 \
+        --output artifacts/published-results
+"""
+
+import argparse
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from debugDump import setDebug
+from vse import CsvBatch, KSModel, allSystems, fuzzyMediaFor
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--elections", type=int, default=15_000)
+    parser.add_argument("--seed", default="target15000")
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=Path("artifacts/published-results"),
+        help="Filename prefix; the runner appends a numeric CSV suffix.",
+    )
+    args = parser.parse_args()
+
+    setDebug(False)
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    batch = CsvBatch(
+        KSModel(dcdecay=(1, 3), wcdecay=(1.5, 3), dccut=.2, wcalpha=1.5),
+        allSystems,
+        nvot=40,
+        ncand=6,
+        niter=args.elections,
+        baseName=str(args.output),
+        media=fuzzyMediaFor(),
+        seed=args.seed,
+        force=True,
+        retain_rows=False,
+    )
+    print(batch.output_file)
+
+
+if __name__ == "__main__":
+    main()

--- a/vseCheck.R
+++ b/vseCheck.R
@@ -35,7 +35,11 @@ library(scatterD3)
 # 
 # fvse = rbind(fvse,fread("wtf2.csv"))
 
-fvse = fread("target3.csv")
+args = commandArgs(trailingOnly = TRUE)
+if (length(args) != 1) {
+  stop("Usage: Rscript vseCheck.R PATH_TO_RESULTS.csv")
+}
+fvse = fread(args[[1]])
 fuzVses = fvse[,mean(util-rand)/mean(best-rand),by=list(method,chooser)]
 etype = fvse[method=="Schulze" & chooser=="honBallot",tallyVal0,by=eid]
 names(etype) = c("eid","scenario")


### PR DESCRIPTION
Closes #20.

Adds a documented full-results generator for the chart analysis and changes `vseCheck.R` to accept the generated CSV path explicitly. Generated simulation output remains untracked.

Validation:
- `uv run python scripts/generate_published_results.py --elections 1 --output /tmp/vse-published-smoke`
- `uv run python -m pytest -q`

## Summary by Sourcery

Make chart analysis data generation reproducible by introducing a scripted CSV generator and updating the R analysis to consume an explicit results file path.

New Features:
- Add a Python script to generate the full simulation CSV used by the published chart analysis with configurable elections, seed, and output prefix.

Enhancements:
- Update the R-based chart analysis to accept a results CSV path via command-line arguments instead of relying on a hardcoded filename.

Documentation:
- Add a chart reproduction guide documenting how to generate the published results CSV and run the historical R analysis.
- Update the README to point to the chart reproduction guide for generating the chart simulation data.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a command-line tool to generate the full simulation CSV used for chart analysis, with configurable elections count, seed, and output location.
  * Updated chart analysis to take the input CSV path as a runtime argument (instead of using a fixed file).
* **Documentation**
  * Added a chart reproduction guide explaining how to regenerate the published charts and produce the full simulation CSV.
  * Updated the README to link to the guide.
* **Chores**
  * Adjusted the CI trunk check configuration to run without post-annotation posting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->